### PR TITLE
Divide all sleep durations by 1000.

### DIFF
--- a/quickstack2.cc
+++ b/quickstack2.cc
@@ -21,7 +21,7 @@
 #include <sys/stat.h>   // stat, stat()
 #include <sys/time.h>   // gettimeofday()
 
-#include <unistd.h>     // fork(), sleep()
+#include <unistd.h>     // fork()
 #include <dirent.h>     // opendir(), readdir(), closedir()
 #include <getopt.h>     // no_argument, required_argument, getopt_long()
 
@@ -33,7 +33,9 @@
 
 #include <algorithm>
 #include <cassert>
+#include <chrono>
 #include <sstream>
+#include <thread>
 
 #include "quickstack2.h"
 
@@ -1389,7 +1391,7 @@ int cont_process_if(int pid) {
     int rc = kill(pid, SIGCONT);
     if (rc == ESRCH)
       return 0;
-    sleep(2);
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
   }
   if (is_stopped) {
     DBG(1, "Failed to start pid %d", pid);
@@ -1459,14 +1461,14 @@ int main(int argc, char** argv) {
       DBG(1, "Got error on waitpid: %d", exited_pid);
     } else if (exited_pid == 0) {
       /* quickstack2 is running */
-      sleep(1);
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
       gettimeofday(&t_current, 0);
       if (t_current.tv_sec >= t_begin.tv_sec + timeout_seconds) {
         DBG(1,
             "Timeout %d seconds reached. Killing quickstack2..",
             timeout_seconds);
         kill(quickstack2_core_pid, SIGKILL);
-        sleep(1);
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
       }
     } else {
       /* quickstack2 ended */
@@ -1483,7 +1485,7 @@ int main(int argc, char** argv) {
   if (WIFSIGNALED(status)) {
     DBG(1, "Killed by signal %d", WTERMSIG(status));
     cleanup_needed = true;
-    sleep(5);
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
   }
   if (*_attach_started) {
     int stop_status = cont_all_process(target_pid, threads, cleanup_needed);


### PR DESCRIPTION
I am not sure if its worth keeping these at all, but presently sleeping can sometimes dominate the total required run time.