### PR TITLE
Add two example programs.

### DIFF
--- a/examples/example-1.md
+++ b/examples/example-1.md
@@ -1,0 +1,72 @@
+# A `quickstack2` example: running something simple
+
+Most of the work in quickstack2 is done with `ptrace` and the BFD library: both,
+particularly BFD, require that the executable is compiled with certain
+visibility settings. The easiest way to get this to work is to link everything
+in statically. Here is a simple C program that computes `147`:
+
+```c
+double s;
+void burn(int n)
+{
+  for (unsigned int i = 0; i < n; ++i)
+    for (unsigned int j = 1; j < 100000; ++j)
+      s += 1. / j * i;
+}
+int main()
+{
+  burn(10000);
+  return s;
+}
+```
+
+We can compile and run this with
+```
+> gcc -O1 -static test.c
+> ./a.out ; echo $?
+147
+```
+
+if we manage to start quickstack2 while this is running we get
+```
+> build]$ ./quickstack2 -b -f --debug=0 -p $(pidof a.out )
+Thread 1 (LWP 31456):
+#01  0x0000000000401b9d in burn () from a.out
+#02  0x0000000000401bc2 in main () from a.out
+```
+
+We have to be careful to see when functions are inlined or not: if we compile
+with higher optimizations, i.e.,
+
+```
+> gcc -O3 -static test.c
+```
+
+and then run the program and quickstack we get
+
+```
+> ./quickstack2 -b -f --debug=0 -p $(pidof a.out )
+
+Thread 1 (LWP 32267):
+#01  0x00000000004015bc in main () from a.out
+```
+
+so the function is in fact inlined. If we switch the declaration of `burn` to
+
+```c
+void __attribute__ ((noinline)) burn(int n)
+```
+
+then we get what we expect again:
+
+```
+> ./quickstack2 -b -f --debug=0 -p $(pidof a.out )
+
+Thread 1 (LWP 2539):
+#01  0x0000000000401bbc in burn () from a.out
+#02  0x000000000040159a in main () from a.out
+```
+
+As mentioned in the introduction, we should always compile with
+`-fno-omit-frame-pointer` too, but that is not an issue here since `burn` only
+uses a single 32-bit register.

--- a/examples/example-2.md
+++ b/examples/example-2.md
@@ -1,0 +1,66 @@
+# A `quickstack2` example: dynamic linking
+
+Compiling with the correct symbol visibility settings is a bit tricky with
+quickstack2: BFD needs to be able to find all the symbols to get their names and
+they are not, by default, available. Consider the following C++ program:
+
+```cpp
+#include <chrono>
+#include <thread>
+
+class Vec
+{
+public:
+  void operator[](const std::size_t i)
+  {
+    std::this_thread::sleep_for(std::chrono::milliseconds(2));
+    index += i;
+  }
+
+protected:
+  std::size_t index = 0;
+};
+
+
+int main()
+{
+  Vec vec;
+  for (unsigned int i = 0; i < 100000; ++i)
+    {
+      vec[i];
+    }
+}
+```
+
+We can compile and run this with
+```
+> g++ -O0 test.cc
+> ./a.out # this may take awhile
+```
+
+if we start quickstack2 while this is running we get
+```
+> ./quickstack2 -b -f --debug=0 -p $(pidof a.out )
+
+Thread 1 (LWP 3622):
+```
+
+i.e., nothing: quickstack2 cannot find the symbols in the executable file that
+correspond to the current address. The easy fix for this is to use `ld.gold`,
+i.e., the `gold` linker:
+
+```
+> gcc -fuse-ld=gold -O0 test.cc
+```
+
+and then run the program and quickstack we get
+
+```
+> ./quickstack2 -b -f --debug=0 -p $(pidof a.out )
+
+Thread 1 (LWP 6749):
+#01  0x00005611165667fb in Vec::operator[] () from a.out
+#02  0x000056111656675a in main () from a.out
+```
+
+which is what we expected.


### PR DESCRIPTION
These show how to compile an executable in a way that quickstack2 can get symbols out of it: both static linking and linking with `gold` work.